### PR TITLE
fix: 修复首页显示问题

### DIFF
--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -15,7 +15,7 @@
         </div>
         <div class="summary-item">
           <div class="amount balance" :class="{ 'negative': summaryData.monthlyBalance < 0 }">
-            ¥{{ formatAmount(Math.abs(summaryData.monthlyBalance)) }}
+            {{ summaryData.monthlyBalance < 0 ? '-' : '' }}¥{{ formatAmount(Math.abs(summaryData.monthlyBalance)) }}
           </div>
           <div class="label">本月结余</div>
         </div>
@@ -48,6 +48,7 @@
             <div class="record-info">
               <div class="record-category">
                 {{ getCategoryIcon(record.categoryIcon) }} {{ record.categoryName }}
+                <span v-if="record.remark" class="record-remark">· {{ record.remark }}</span>
               </div>
               <div class="record-date">{{ formatDate(record.date) }}</div>
             </div>
@@ -343,6 +344,17 @@ onMounted(() => {
   font-weight: 500;
   color: var(--color-text-primary);
   margin-bottom: 2px;
+  display: flex;
+  align-items: center;
+}
+
+.record-remark {
+  color: var(--color-text-secondary);
+  font-weight: normal;
+  margin-left: var(--space-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .record-date {

--- a/src/views/Settings/Help.vue
+++ b/src/views/Settings/Help.vue
@@ -167,11 +167,11 @@
             <van-icon name="arrow" class="copy-icon" />
           </div>
 
-          <div class="contact-item" @click="copyToClipboard('https://github.com/chulingera2025')">
+          <div class="contact-item" @click="copyToClipboard('https://github.com/chulingera2025/MochiMoney')">
             <van-icon name="link-o" />
             <div class="contact-text">
               <div class="contact-label">Github地址</div>
-              <div class="contact-value">https://github.com/chulingera2025</div>
+              <div class="contact-value">https://github.com/chulingera2025/MochiMoney</div>
             </div>
             <van-icon name="arrow" class="copy-icon" />
           </div>


### PR DESCRIPTION
## Summary
- 修复汇总卡片本月结余负数显示问题，现在能正确显示负数符号
- 修复最近记录部分不显示备注信息的问题
- 添加备注信息的样式，保持与记录详情页面一致

## Test plan
- [x] 测试本月结余为负数时的显示效果
- [x] 测试最近记录中备注信息的显示
- [x] 验证样式与记录详情页面一致